### PR TITLE
fix github ribbon clickability

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -12,7 +12,7 @@
   {{ super() }}
   <a href="https://github.com/spacetelescope/understanding-json-schema"
      class="visible-desktop"><img
-    style="position: absolute; top: 40px; right: 0; border: 0;"
+    style="position: absolute; z-index: 10; top: 40px; right: 0; border: 0;"
     src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png"
     alt="Fork me on GitHub"></a>
 {% endblock %}


### PR DESCRIPTION
Before, the GitHub ribbon was not clickable (at least in my browser - Chrome 33.0.1750.152, Ubuntu 13.10).
