### PR TITLE
Fix failing validation of example

### DIFF
--- a/source/about.rst
+++ b/source/about.rst
@@ -155,7 +155,7 @@ for now.  They are explained in subsequent chapters.
       "properties": {
         "first_name": { "type": "string" },
         "last_name": { "type": "string" },
-        "birthday": { "type": "string", "format": "date-time" },
+        "birthday": { "type": "string", "format": "date" },
         "address": {
           "type": "object",
           "properties": {


### PR DESCRIPTION
The example specifies a `date-time` format for the birthday but the given data which is supposed to correctly validate fails because the birthday is only a date.

Fix updates the formate to `date`.