### PR TITLE
fixed "birthday" in from `date` to `date-time`

### DIFF
--- a/source/about.rst
+++ b/source/about.rst
@@ -156,7 +156,7 @@ for now.  They are explained in subsequent chapters.
       "properties": {
         "first_name": { "type": "string" },
         "last_name": { "type": "string" },
-        "birthday": { "type": "string", "format": "date-time" },
+        "birthday": { "type": "string", "format": "date" },
         "address": {
           "type": "object",
           "properties": {


### PR DESCRIPTION
https://json-schema.org/understanding-json-schema/about.html#about

in the json body, it is 
"birthday": "22-02-1732",
But in json schema, it is wrong. No time info in the `birthday`
"birthday": { "type": "string", "format": "date-time" },

So I changed it to : 
"birthday": { "type": "string", "format": "date" },

