### PR TITLE
Fixed minor typo in numeric.rst -> exclusiveMinimum to exclusiveMaximum

### DIFF
--- a/source/reference/numeric.rst
+++ b/source/reference/numeric.rst
@@ -160,7 +160,7 @@ If *x* is the value being validated, the following must hold true:
   - *x* < ``exclusiveMaximum``
 
 While you can specify both of ``minimum`` and ``exclusiveMinimum`` or both of
-``maximum`` and ``exclusiveMinimum``, it doesn't really make sense to do so.
+``maximum`` and ``exclusiveMaximum``, it doesn't really make sense to do so.
 
 .. schema_example::
 


### PR DESCRIPTION
Original text says "While you can specify both of minimum and exclusiveMinimum or both of maximum and exclusiveMinimum, it doesn’t really make sense to do so." Clearly the intent was to say "...or both of maximum and exclusive**Maximum**."

Just a very minor typo, thanks for the great overview of JSON schema!

