### PR TITLE
correct URI for definitions in separate file

### DIFF
--- a/source/structuring.rst
+++ b/source/structuring.rst
@@ -95,7 +95,7 @@ the keys in the objects in the document. Therefore, in our example
 include your definitions in separate files, you can also do that.  For
 example::
 
-    { "$ref": "definitions.json#/address" }
+    { "$ref": "definitions.json/#/address" }
 
 would load the address schema from another file residing alongside
 this one.


### PR DESCRIPTION
It seems to me that there is a "/" missing in the example given so I have added it.