### PR TITLE
clarify which draft changed exclusiveMin/Max

### DIFF
--- a/source/reference/numeric.rst
+++ b/source/reference/numeric.rst
@@ -188,10 +188,10 @@ While you can specify both of ``minimum`` and ``exclusiveMinimum`` or both of
     // Greater than ``maximum``:
     101
 
-.. language_specific::
+.. draft_specific::
 
-    --Draft 4
-    In JSON Schema Draft 4, ``exclusiveMinimum`` and ``exclusiveMaximum`` work
+    --Draft 4-6
+    The behavior of ``exclusiveMinimum`` and ``exclusiveMaximum`` changed in Draft 6. Before Draft 6 they work
     differently. There they are boolean values, that indicate whether
     ``minimum`` and ``maximum`` are exclusive of the value. For example:
 


### PR DESCRIPTION
exclusiveMinimum and exclusiveMaximum changed from boolean to number in draft 6.
But this document implies that that change happened after draft 4 (ie in draft 5).
So, make it clear that draft 5 has the booleans too.