### PR TITLE
Lookaheads use parens (on both sides)

### DIFF
--- a/source/reference/regular_expressions.rst
+++ b/source/reference/regular_expressions.rst
@@ -53,7 +53,7 @@ syntax described below.
   behavior isn't desired and you want to match as few characters as
   possible.
   
-- ``(?!x}``, ``(?=x}``: Negative and positive lookahead.
+- ``(?!x)``, ``(?=x)``: Negative and positive lookahead.
 
 - ``{x}``: Match exactly ``x`` occurrences of the preceding regular
   expression.


### PR DESCRIPTION
See "Note 3" in ECMA-262 here:
http://www.ecma-international.org/ecma-262/9.0/index.html#sec-runtime-semantics-canonicalize-ch

I am unaware of any regex grouping element that opens w/ parenthesis, but closes with a non-paren character.