### PR TITLE
Fix E. M. Bray formatting

### DIFF
--- a/source/credits.rst
+++ b/source/credits.rst
@@ -15,7 +15,7 @@ Michael Droettboom wishes to thank the following contributors:
 - David Branner
 - David Michael Karr
 - David Worth
-- E. M. Bray
+- E\. M\. Bray
 - Fenhl
 - forevermatt
 - goldaxe


### PR DESCRIPTION
When "Erik Bray" was changed to "E. M. Bray", it caused some _very_ strange side effects in the list formatting, because <strike>Markdown</strike> the ReStructuredText parser (in its infinite weirdness) considers both the `E.` and `M.` to be ordered sublist labels. Escaping the periods un-confuses the parser.