### PR TITLE
Fix lookahead syntax - ")", not "}"

### DIFF
--- a/source/reference/regular_expressions.rst
+++ b/source/reference/regular_expressions.rst
@@ -53,7 +53,7 @@ syntax described below.
   behavior isn't desired and you want to match as few characters as
   possible.
   
-- ``(?!x}``, ``(?=x}``: Negative and positive lookahead.
+- ``(?!x)``, ``(?=x)``: Negative and positive lookahead.
 
 - ``{x}``: Match exactly ``x`` occurrences of the preceding regular
   expression.


### PR DESCRIPTION
I think this was just a typo.