### PR TITLE
Update docs with deprecated version-less $schema

### DIFF
--- a/source/reference/schema.rst
+++ b/source/reference/schema.rst
@@ -31,7 +31,7 @@ example:
 - ``http://json-schema.org/draft-06/schema#``
 - ``http://json-schema.org/draft-04/schema#``
 
-Possibility to declare ``$schema`` without specific version (``http://json-schema.org/schema#``) was deprecated after Draft 4 and should no longer be used.
+The possibility to declare ``$schema`` without specific version (``http://json-schema.org/schema#``) was deprecated after Draft 4 and should no longer be used.
 
 Additionally, if you have extended the JSON Schema language to include
 your own custom keywords for validating values, you can use a custom

--- a/source/reference/schema.rst
+++ b/source/reference/schema.rst
@@ -17,18 +17,21 @@ It is recommended that all JSON Schemas have a ``$schema`` entry,
 which must be at the root.  Therefore most of the time, you'll want
 this at the root of your schema::
 
-    "$schema": "http://json-schema.org/schema#"
+    "$schema": "http://json-schema.org/draft/2019-09/schema#"
 
 Advanced
 --------
 
-If you need to declare that your schema was written against a specific version
-of the JSON Schema standard, you should include the draft name in the path, for
+You should declare that your schema was written against a specific version
+of the JSON Schema standard and include the draft name in the path, for
 example:
 
+- ``http://json-schema.org/draft/2019-09/schema#``
 - ``http://json-schema.org/draft-07/schema#``
 - ``http://json-schema.org/draft-06/schema#``
 - ``http://json-schema.org/draft-04/schema#``
+
+Possibility to declare ``$schema`` without specific version (``http://json-schema.org/schema#``) was deprecated in Draft 4 and should no longer be used.
 
 Additionally, if you have extended the JSON Schema language to include
 your own custom keywords for validating values, you can use a custom

--- a/source/reference/schema.rst
+++ b/source/reference/schema.rst
@@ -31,7 +31,7 @@ example:
 - ``http://json-schema.org/draft-06/schema#``
 - ``http://json-schema.org/draft-04/schema#``
 
-Possibility to declare ``$schema`` without specific version (``http://json-schema.org/schema#``) was deprecated in Draft 4 and should no longer be used.
+Possibility to declare ``$schema`` without specific version (``http://json-schema.org/schema#``) was deprecated after Draft 4 and should no longer be used.
 
 Additionally, if you have extended the JSON Schema language to include
 your own custom keywords for validating values, you can use a custom


### PR DESCRIPTION
Version-less $schema keyword:

```json
"$schema": "http://json-schema.org/schema#"
```

was deprecated after Draft 4.

For more information see davishmcclurg/json_schemer#63.