### PR TITLE
Fix trailing commas in invalid examples

### DIFF
--- a/source/reference/object.rst
+++ b/source/reference/object.rst
@@ -60,7 +60,7 @@ conventionally referred to as a "property".
     --X
     // Using non-strings as keys is invalid JSON:
     {
-        0.01 : "cm"
+        0.01 : "cm",
         1    : "m",
         1000 : "km"
     }
@@ -238,7 +238,7 @@ they don't provide their address or telephone number:
     // invalid:
     {
       "name": "William Shakespeare",
-      "address": "Henley Street, Stratford-upon-Avon, Warwickshire, England",
+      "address": "Henley Street, Stratford-upon-Avon, Warwickshire, England"
     }
 
 .. index::


### PR DESCRIPTION
Technically there's nothing wrong with these examples because they're
claimed to be invalid and they are invalid, but neither of them are
supposed to be invalid due to incorrect usage of trailing commas. This
commit allows these examples to more clearly demonstrate what they are
meant to show.