### PR TITLE
Replace jsonschema.net with jsonschema.dev

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -46,7 +46,7 @@ validator---just yet.
   resources, including the official specification and tools for
   working with JSON Schema from various programming languages.
 
-- `jsonschema.net <http://jsonschema.net>`__ is an online application
+- `jsonschema.dev <https://jsonschema.dev>`__ is an online application
   run your own JSON schemas against example documents.  If you want to
   try things out without installing any software, it's a very handy
   resource.


### PR DESCRIPTION
I noticed that Understanding JSON Schema is pointing people `jsonschema.net`. Given the problems we have with their tooling and their lack of response when we asked to fix them to fix the problem, we should definitely not be sending people to that site.