### PR TITLE
Draft7 general cleanup

### DIFF
--- a/source/about.rst
+++ b/source/about.rst
@@ -58,11 +58,11 @@ may go by different names.
 .. language_specific::
 
     --Python
-    The following table maps from the names of JavaScript types to
-    their analogous types in Python:
+    The following table maps from the names of JSON types to their
+    analogous types in Python:
 
     +----------+-----------+
-    |JavaScript|Python     |
+    |JSON      |Python     |
     +----------+-----------+
     |string    |string     |
     |          |[#1]_      |
@@ -81,19 +81,19 @@ may go by different names.
 
     .. rubric:: Footnotes
 
-    .. [#1] Since JavaScript strings always support unicode, they are
+    .. [#1] Since JSON strings always support unicode, they are
             analogous to ``unicode`` on Python 2.x and ``str`` on
             Python 3.x.
 
-    .. [#2] JavaScript does not have separate types for integer and
+    .. [#2] JSON does not have separate types for integer and
             floating-point.
 
     --Ruby
-    The following table maps from the names of JavaScript types to
-    their analogous types in Ruby:
+    The following table maps from the names of JSON types to their
+    analogous types in Ruby:
 
     +----------+----------------------+
-    |JavaScript|Ruby                  |
+    |JSON      |Ruby                  |
     +----------+----------------------+
     |string    |String                |
     +----------+----------------------+
@@ -111,7 +111,7 @@ may go by different names.
 
     .. rubric:: Footnotes
 
-    .. [#3] JavaScript does not have separate types for integer and
+    .. [#3] JSON does not have separate types for integer and
             floating-point.
 
 With these simple data types, all kinds of structured data can be
@@ -181,7 +181,7 @@ for now.  They are explained in subsequent chapters.
     {
       "first_name": "George",
       "last_name": "Washington",
-      "birthday": "22-02-1732",
+      "birthday": "1732-02-22",
       "address": {
         "street_address": "3200 Mount Vernon Memorial Highway",
         "city": "Mount Vernon",

--- a/source/basics.rst
+++ b/source/basics.rst
@@ -80,10 +80,11 @@ The ``type`` keyword is described in more detail in `type`.
 Declaring a JSON Schema
 -----------------------
 
-Since JSON Schema is itself JSON, it's not always easy to tell when
-something is JSON Schema or just an arbitrary chunk of JSON.  The
-``$schema`` keyword is used to declare that something is JSON Schema.
-It's generally good practice to include it, though it is not required.
+It's not always easy to tell which draft a JSON Schema is using. You
+can use the ``$schema`` keyword to declare which version of the JSON
+Schema specification the schema is written to. See `schema` for more
+information. It's generally good practice to include it, though it is
+not required.
 
 .. note::
     For brevity, the ``$schema`` keyword isn't included in most of the
@@ -92,11 +93,15 @@ It's generally good practice to include it, though it is not required.
 
 .. schema_example::
 
-    { "$schema": "http://json-schema.org/schema#" }
+    { "$schema": "http://json-schema.org/draft-07/schema#" }
 
-You can also use this keyword to declare which version of the JSON
-Schema specification that the schema is written to.  See `schema` for
-more information.
+.. draft_specific::
+
+    --Draft 4
+    In Draft 4, a ``$schema`` value of
+    ``http://json-schema.org/schema#`` referred to the latest version
+    of JSON Schema. This usage has since been deprecated and the use
+    of specific version URIs is required.
 
 Declaring a unique identifier
 -----------------------------

--- a/source/conventions.rst
+++ b/source/conventions.rst
@@ -40,15 +40,15 @@ JSON in a few different languages:
 Draft-specific notes
 --------------------
 
-The JSON Schema standard has been through a number of revisions or "drafts". The
-most important are Draft 7, the most recent at the time of this writing, and
-Draft 4, on which a lot of production software was built, and the draft for
-which an earlier version of this book was written.
+The JSON Schema standard has been through a number of revisions or
+"drafts". The the current version is Draft 7, but Draft 4 is still
+widely used as well.
 
-The text is written to encourage the use of Draft 7 and gives priority to the
-latest conventions and features, but where it differs from earlier drafts, those
-differences are highlighted in special call-outs. If you only wish to target
-Draft 7, you can safely ignore those sections.
+The text is written to encourage the use of Draft 7 and gives priority
+to the latest conventions and features, but where it differs from
+earlier drafts, those differences are highlighted in special
+call-outs. If you only wish to target Draft 7, you can safely ignore
+those sections.
 
 |draft7|
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -46,10 +46,10 @@ validator---just yet.
   resources, including the official specification and tools for
   working with JSON Schema from various programming languages.
 
-- `jsonschema.dev <https://jsonschema.dev>`__ is an online application
-  run your own JSON schemas against example documents.  If you want to
-  try things out without installing any software, it's a very handy
-  resource.
+- There are a number of `online JSON Schema tools <https://json-schema.org/implementations.html#validator-web%20(online)>`__
+  that allow you to run your own JSON schemas against example
+  documents. These can be very handy if you want to try things out
+  without installing any software.
 
 .. only:: html
 

--- a/source/reference/type.rst
+++ b/source/reference/type.rst
@@ -13,7 +13,8 @@ data type for a schema.
 At its core, JSON Schema defines the following basic types:
 
    - `string`
-   - `numeric`
+   - `number <number>`
+   - `integer <integer>`
    - `object`
    - `array`
    - `boolean`
@@ -25,11 +26,11 @@ may go by different names.
 .. language_specific::
 
     --Python
-    The following table maps from the names of JavaScript types to
-    their analogous types in Python:
+    The following table maps from the names of JSON types to their
+    analogous types in Python:
 
     +----------+-----------+
-    |JavaScript|Python     |
+    |JSON      |Python     |
     +----------+-----------+
     |string    |string     |
     |          |[#1]_      |
@@ -48,20 +49,20 @@ may go by different names.
 
     .. rubric:: Footnotes
 
-    .. [#1] Since JavaScript strings always support unicode, they are
+    .. [#1] Since JSON strings always support unicode, they are
             analogous to ``unicode`` on Python 2.x and ``str`` on
             Python 3.x.
 
-    .. [#2] JavaScript does not have separate types for integer and
+    .. [#2] JSON does not have separate types for integer and
             floating-point.
 
 
     --Ruby
-    The following table maps from the names of JavaScript types to
-    their analogous types in Ruby:
+    The following table maps from the names of JSON types to their
+    analogous types in Ruby:
 
     +----------+----------------------+
-    |JavaScript|Ruby                  |
+    |JSON      |Ruby                  |
     +----------+----------------------+
     |string    |String                |
     +----------+----------------------+
@@ -79,7 +80,7 @@ may go by different names.
 
     .. rubric:: Footnotes
 
-    .. [#3] JavaScript does not have separate types for integer and
+    .. [#3] JSON does not have separate types for integer and
             floating-point.
 
 The ``type`` keyword may either be a string or an array:


### PR DESCRIPTION
I'm going to be updating the website for 2020-12, but first I want to go through and fixup anything that is incorrect or unclear in what we have right now. This is the beginning.

*Changes*

* The docs often talk about "JavaScript types", but "JSON types" is more accurate. This is JSON Schema, not JavaScript Schema.
* The introduction to `$schema` didn't make much sense and used the deprecated `http://json-schema.org/schema#` URI
* Instead of suggesting a specific online validator, point to implementations page that lists several options.