### PR TITLE
Cleanup and fixes for null keywords

### DIFF
--- a/source/reference/null.rst
+++ b/source/reference/null.rst
@@ -6,9 +6,13 @@
 null
 ----
 
-The null type is generally used to represent a missing value.  When a
-schema specifies a ``type`` of ``null``, it has only one acceptable
-value: ``null``.
+When a schema specifies a ``type`` of ``null``, it has only one
+acceptable value: ``null``.
+
+.. note::
+
+   It's important to remember that in JSON, ``null`` isn't equivalent
+   to something being absent. See `required` for an example.
 
 .. language_specific::
 
@@ -28,3 +32,5 @@ value: ``null``.
     0
     --X
     ""
+    --X
+


### PR DESCRIPTION
This section incorrectly equates a JSON `null` value to something being missing. I think this is more accurate.