### PR TITLE
Add docker config for local builds

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,4 +1,0 @@
-Prerequisites
-=============
-
-> pip install sphinx sphinx-bootstrap-theme jsonschema

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM fedora
+
+# Install texlive
+RUN dnf update -y
+RUN dnf install -y make latexmk texlive
+RUN dnf install -y 'tex(fncychap.sty)' \
+                   'tex(tabulary.sty)' \
+                   'tex(framed.sty)' \
+                   'tex(wrapfig.sty)' \
+                   'tex(upquote.sty)' \
+                   'tex(capt-of.sty)' \
+                   'tex(needspace.sty)' \
+                   'tex(overlock.sty)' \
+                   'tex(inconsolata.sty)' \
+                   'tex(bbding.sty)' \
+                   'tex(mdframed.sty)' \
+                   'tex(bbding10.pfb)'
+RUN texhash
+
+# Install sphinx
+RUN pip install "sphinx<2.0.0" sphinx-bootstrap-theme jsonschema
+
+COPY . /code
+WORKDIR /code
+
+# Build and serve website
+CMD make html latexpdf && cp build/latex/*.pdf build/html && python3 -m http.server 8000 --directory build/html

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-sphinx = "*"
+sphinx = "<2.0.0"
 sphinx-bootstrap-theme = "*"
 jsonschema = "*"
 

--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ A website aiming to provide more accessible documentation for JSON schema.
 http://json-schema.org/understanding-json-schema/index.html
 
 [![Build Status](https://travis-ci.org/json-schema-org/understanding-json-schema.png)](https://travis-ci.org/json-schema-org/understanding-json-schema)
+
+## Build locally
+
+You can build and serve the website locally using docker. Running
+`docker-compose up` will start the server on http://localhost:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.9"
+
+services:
+  web:
+    build: .
+    volumes:
+      - .:/code:Z
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
As much as I tried to avoid it, I had to setup a local build. I set it up so that all you have to do is run `docker-compose up` to build and serve the website locally.

I couldn't get `install-texlive.sh` to work, but I kept it around anyway because it's used in the travis deploy process.

The build doesn't exactly match the live build, but it's close enough. I only see small differences in whitespace in some places.