### PR TITLE
Cleanup and fixes for combining

### DIFF
--- a/source/reference/combining.rst
+++ b/source/reference/combining.rst
@@ -1,10 +1,10 @@
 .. index::
-   single: combining schemas
+   single: schema composition
 
 .. _combining:
 
-Combining schemas
-=================
+Schema Composition
+==================
 
 .. contents:: :local:
 
@@ -15,46 +15,27 @@ that and are described in `structuring`.  Combining schemas may be as
 simple as allowing a value to be validated against multiple criteria
 at the same time.
 
-For example, in the following schema, the ``anyOf`` keyword is used to
-say that the given value may be valid against any of the given
-subschemas.  The first subschema requires a string with maximum
-length 5. The second subschema requires a number with a minimum value
-of 0.  As long as a value validates against *either* of these schemas,
-it is considered valid against the entire combined schema.
-
-.. schema_example::
-
-    {
-      "anyOf": [
-        { "type": "string", "maxLength": 5 },
-        { "type": "number", "minimum": 0 }
-      ]
-    }
-    --
-    "short"
-    --X
-    "too long"
-    --
-    12
-    --X
-    -5
+These keywords correspond to well known boolean algebra concepts like
+AND, OR, XOR, and NOT. You can often use these keywords to express
+complex constraints that can't otherwise be expressed with standard
+JSON Schema keywords.
 
 The keywords used to combine schemas are:
 
-- `allOf`: Must be valid against *all* of the subschemas
-- `anyOf`: Must be valid against *any* of the subschemas
-- `oneOf`: Must be valid against *exactly one* of the subschemas
+- `allOf`: (AND) Must be valid against *all* of the subschemas
+- `anyOf`: (OR) Must be valid against *any* of the subschemas
+- `oneOf`: (XOR) Must be valid against *exactly one* of the subschemas
 
 All of these keywords must be set to an array, where each item is a
 schema.
 
 In addition, there is:
 
-- `not`: Must *not* be valid against the given schema
+- `not`: (NOT) Must *not* be valid against the given schema
 
 .. index::
    single: allOf
-   single: combining schemas; allOf
+   single: schema composition; allOf
 
 .. _allOf:
 
@@ -77,112 +58,16 @@ of the given subschemas.
     --X
     "too long"
 
-Note that it's quite easy to create schemas that are logical
-impossibilities with ``allOf``.  The following example creates a schema
-that won't validate against anything (since something may not be both
-a string and a number at the same time):
-
-.. schema_example::
-
-    {
-      "allOf": [
-        { "type": "string" },
-        { "type": "number" }
-      ]
-    }
-    --X
-    "No way"
-    --X
-    -1
-
-It is important to note that the schemas listed in an `allOf`, `anyOf`
-or `oneOf` array know nothing of one another.  While it might be
-surprising, `allOf` can not be used to "extend" a schema to add more
-details to it in the sense of object-oriented inheritance.  For
-example, say you had a schema for an address in a ``definitions``
-section, and want to extend it to include an address type:
-
-.. schema_example::
-
-   {
-     "definitions": {
-       "address": {
-         "type": "object",
-         "properties": {
-           "street_address": { "type": "string" },
-           "city":           { "type": "string" },
-           "state":          { "type": "string" }
-         },
-         "required": ["street_address", "city", "state"]
-       }
-     },
-
-     "allOf": [
-       { "$ref": "#/definitions/address" },
-       { "properties": {
-           "type": { "enum": [ "residential", "business" ] }
-         }
-       }
-     ]
-   }
-   --
-   {
-      "street_address": "1600 Pennsylvania Avenue NW",
-      "city": "Washington",
-      "state": "DC",
-      "type": "business"
-   }
-
-This works, but what if we wanted to restrict the schema so no
-additional properties are allowed?  One might try adding the
-highlighted line below:
-
-.. schema_example::
-
-   {
-     "definitions": {
-       "address": {
-         "type": "object",
-         "properties": {
-           "street_address": { "type": "string" },
-           "city":           { "type": "string" },
-           "state":          { "type": "string" }
-         },
-         "required": ["street_address", "city", "state"]
-       }
-     },
-
-     "allOf": [
-       { "$ref": "#/definitions/address" },
-       { "properties": {
-           "type": { "enum": [ "residential", "business" ] }
-         }
-       }
-     ],
-
-     *"additionalProperties": false
-   }
-   --X
-   {
-      "street_address": "1600 Pennsylvania Avenue NW",
-      "city": "Washington",
-      "state": "DC",
-      "type": "business"
-   }
-
-Unfortunately, now the schema will reject *everything*.  This is
-because the `additionalProperties` refers to the entire schema.  And
-that entire schema includes no properties, and knows nothing about the
-properties in the subschemas inside of the `allOf` array.
-
-This shortcoming is perhaps one of the biggest surprises of the
-combining operations in JSON schema: it does not behave like
-inheritance in an object-oriented language.  There are some proposals
-to address this in the next version of the JSON schema specification.
+.. note::
+   `allOf` can not be used to "extend" a schema to add more details to
+   it in the sense of object-oriented inheritance. Instances must
+   independently be valid against "all of" the schemas in the
+   ``allOf``. See the section on `subschemaindependence` for more
+   information.
 
 .. index::
    single: anyOf
-   single: combining schemas; anyOf
+   single: schema composition; anyOf
 
 .. _anyOf:
 
@@ -194,22 +79,24 @@ To validate against ``anyOf``, the given data must be valid against any
 
 .. schema_example::
 
-   {
-     "anyOf": [
-       { "type": "string" },
-       { "type": "number" }
-     ]
-   }
-   --
-   "Yes"
-   --
-   42
-   --X
-   { "Not a": "string or number" }
+    {
+      "anyOf": [
+        { "type": "string", "maxLength": 5 },
+        { "type": "number", "minimum": 0 }
+      ]
+    }
+    --
+    "short"
+    --X
+    "too long"
+    --
+    12
+    --X
+    -5
 
 .. index::
    single: oneOf
-   single: combining schemas; oneOf
+   single: schema composition; oneOf
 
 .. _oneOf:
 
@@ -238,33 +125,17 @@ exactly one of the given subschemas.
     // Multiple of *both* 5 and 3 is rejected.
     15
 
-Note that it's possible to "factor" out the common parts of the
-subschemas.  The following schema is equivalent to the one above:
-
-.. schema_example::
-
-   {
-      "type": "number",
-      "oneOf": [
-        { "multipleOf": 5 },
-        { "multipleOf": 3 }
-      ]
-    }
-
 .. index::
    single: not
-   single: combining schemas; not
+   single: schema composition; not
 
 .. _not:
-
 
 not
 ---
 
-This doesn't strictly combine schemas, but it belongs in this chapter
-along with other things that help to modify the effect of schemas in
-some way.  The ``not`` keyword declares that a instance validates if
-it doesn't validate against the given subschema.
+The ``not`` keyword declares that an instance validates if it doesn't
+validate against the given subschema.
 
 For example, the following schema validates against anything that is
 not a string:
@@ -278,3 +149,151 @@ not a string:
     { "key": "value" }
     --X
     "I am a string"
+
+.. index::
+   single: not
+   single: schema composition; subschema independence
+
+.. _composition:
+
+Properties of Schema Composition
+--------------------------------
+
+.. _subschemaindependence:
+
+Subschema Independence
+''''''''''''''''''''''
+
+It is important to note that the schemas listed in an `allOf`, `anyOf`
+or `oneOf` array know nothing of one another. For example, say you had
+a schema for an address in a ``definitions`` section, and want to
+"extend" it to include an address type:
+
+.. schema_example::
+
+   {
+     "definitions": {
+       "address": {
+         "type": "object",
+         "properties": {
+           "street_address": { "type": "string" },
+           "city": { "type": "string" },
+           "state": { "type": "string" }
+         },
+         "required": ["street_address", "city", "state"]
+       }
+     },
+
+     "allOf": [
+       { "$ref": "#/definitions/address" },
+       {
+         "properties": {
+           "type": { "enum": [ "residential", "business" ] }
+         }
+       }
+     ]
+   }
+   --
+   {
+      "street_address": "1600 Pennsylvania Avenue NW",
+      "city": "Washington",
+      "state": "DC",
+      "type": "business"
+   }
+
+This works, but what if we wanted to restrict the schema so no
+additional properties are allowed?  One might try adding the
+highlighted line below:
+
+.. schema_example::
+
+   {
+     "definitions": {
+       "address": {
+         "type": "object",
+         "properties": {
+           "street_address": { "type": "string" },
+           "city": { "type": "string" },
+           "state": { "type": "string" }
+         },
+         "required": ["street_address", "city", "state"]
+       }
+     },
+
+     "allOf": [
+       { "$ref": "#/definitions/address" },
+       {
+         "properties": {
+           "type": { "enum": [ "residential", "business" ] }
+         }
+       }
+     ],
+
+     *"additionalProperties": false
+   }
+   --X
+   {
+      "street_address": "1600 Pennsylvania Avenue NW",
+      "city": "Washington",
+      "state": "DC",
+      "type": "business"
+   }
+
+Unfortunately, now the schema will reject *everything*.  This is
+because ``additionalProperties`` knows nothing about the properties
+declared in the subschemas inside of the `allOf` array.
+
+To many, this is one of the biggest surprises of the combining
+operations in JSON schema: it does not behave like inheritance in an
+object-oriented language. There are some proposals to address this in
+the next version of the JSON schema specification.
+
+.. _illogicalschemas:
+
+Illogical Schemas
+'''''''''''''''''
+
+Note that it's quite easy to create schemas that are logical
+impossibilities with these keywords. The following example creates a
+schema that won't validate against anything (since something may not
+be both a string and a number at the same time):
+
+.. schema_example::
+
+    {
+      "allOf": [
+        { "type": "string" },
+        { "type": "number" }
+      ]
+    }
+    --X
+    "No way"
+    --X
+    -1
+
+.. _factoringschemas:
+
+Factoring Schemas
+'''''''''''''''''
+
+Note that it's possible to "factor" out the common parts of the
+subschemas.  The following two schemas are equivalent.
+
+.. schema_example::
+
+    {
+      "oneOf": [
+        { "type": "number", "multipleOf": 5 },
+        { "type": "number", "multipleOf": 3 }
+      ]
+    }
+
+.. schema_example::
+
+   {
+      "type": "number",
+      "oneOf": [
+        { "multipleOf": 5 },
+        { "multipleOf": 3 }
+      ]
+    }


### PR DESCRIPTION
The bulk of the changes to this section is restructuring. There were parts within each section that described some general property of schema composition. Because those parts were not specific to any keyword, I moved those out into their own section.

I also changed the name of the page from "Combining Schemas" to "Schema Composition". It's a little more jargony, but I wanted to add a little something more to make it clear than JSON Schema works on composition, not inheritance.

I also added reference to the boolean operations each keyword represents.

The rest was efforts to improve wording.