### PR TITLE
Minor typo fix in subsection heading

### DIFF
--- a/source/reference/array.rst
+++ b/source/reference/array.rst
@@ -163,8 +163,8 @@ Here's the example schema:
 
 .. _additionalItems:
 
-Addtional Items
-'''''''''''''''
+Additional Items
+''''''''''''''''
 
 The ``additionalItems`` keyword controls whether it's valid to have
 additional items in a tuple beyond what is defined in ``items``. The


### PR DESCRIPTION
`Addtional` -> `Additional`