### PR TITLE
Correct `$anchor` example

### DIFF
--- a/source/structuring.rst
+++ b/source/structuring.rst
@@ -293,7 +293,7 @@ schema.
       "properties": {
         "street_address":
     *      {
-    *        "$anchor": "#street_address",
+    *        "$anchor": "street_address",
     *        "type": "string"
     *      },
         "city": { "type": "string" },


### PR DESCRIPTION
Anchor names should not contain the fragment #, and neither are they allowed to. Spec: https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.8.2.3

Closes #186