### PR TITLE
clarify that `type` for `additionalProperties` refer to the values

### DIFF
--- a/source/reference/object.rst
+++ b/source/reference/object.rst
@@ -218,7 +218,7 @@ Reusing the example from `properties`, but this time setting
 
 You can use non-boolean schemas to put more complex constraints on the
 additional properties of an instance. For example, one can allow
-additional properties, but only if they are each a string:
+additional properties, but only if their values are each a string:
 
 .. schema_example::
 


### PR DESCRIPTION
When `type` is specified in `additionalProperties`, such as in
the example below,

```
{
  "type": "object",
  "properties": {
    "number": { "type": "number" },
    "street_name": { "type": "string" },
    "street_type": { "enum": ["Street", "Avenue", "Boulevard"] }
  },
  "additionalProperties": { "type": "string" }
}
```

the doc currently says "... one can allow additional properties, but only
if they are each a string".

This is a little confusing, because "they" refers to the properties, and
it is unclear whether "they" refers to property keys or property values.

By changing it to "... one can allow additional properties, but only if
their values are each a string", this statement becomes unambiguous.