### PR TITLE
Fix null type example

### DIFF
--- a/source/reference/null.rst
+++ b/source/reference/null.rst
@@ -23,7 +23,7 @@ acceptable value: ``null``.
 
 .. schema_example::
 
-    { "type": "null" }
+    { "type": null }
     --
     null
     --X


### PR DESCRIPTION
Source: https://www.json.org/json-en.html

> A value can be a string in double quotes, or a number, or true or false or null, or an object or an array. These structures can be nested.

