### PR TITLE
Fix Python data type for string

### DIFF
--- a/source/reference/type.rst
+++ b/source/reference/type.rst
@@ -32,7 +32,7 @@ may go by different names.
     +----------+-----------+
     |JSON      |Python     |
     +----------+-----------+
-    |string    |string     |
+    |string    |str        |
     |          |[#1]_      |
     +----------+-----------+
     |number    |int/float  |


### PR DESCRIPTION
The Python data type should be `str` rather than "string". 