### PR TITLE
add rough docs for unevaluatedItems

### DIFF
--- a/source/reference/array.rst
+++ b/source/reference/array.rst
@@ -248,7 +248,7 @@ that begin with either ``1`` or ``"A"``, but anything after must be ``2``.
 
     {
       "oneOf": [{"prefixItems": [{"const": 1}]}, {"prefixItems": [{"const": "a"}]}],
-      "items": {"const": 2},
+      "items": {"const": 2}
     }
 
 The logic here seems like it should be "one of either ``1`` or ``"A"``
@@ -311,7 +311,7 @@ Instead, keep all your ``unevaluatedItems`` in the same subschema:
           "SKU": "number",
           "product": "string",
           "quantity": { "enum": ["1", "2", "3"] }
-        }
+        },
         "required": ["quantity"]
       },
       "unevaluatedItems": false
@@ -320,15 +320,15 @@ Instead, keep all your ``unevaluatedItems`` in the same subschema:
 Similarly, ``unevaluatedItems`` can't see inside cousins (vertically
 adjacent properties inside a separate pair of {curly braces} with the
 same "parent"— ``anyOf``, ``if``, ``not``, or similar). For instance,
-in the example below, the ``unevaluatedItems`` doesn't "see inside" the
-``prefixItems`` cousin before it. So since ``"prefixItems": [ true ]``
-matches only length 1 arrays, and ``{ "unevaluatedItems": false }``
-matches only empty arrays, all instances fail validation.
+in the example below, the ``unevaluatedItems`` doesn't "see inside"
+the ``prefixItems`` cousin before it. All instances fail vallidation
+because ``"prefixItems": [ true ]`` matches only length 1 arrays, and
+``{ "unevaluatedItems": false }`` matches only empty arrays.
 
 .. schema_example::
 
     {
-      "oneOf": [
+      "allOf": [
         { "prefixItems": [true] },
         { "unevaluatedItems": false }
       ]
@@ -413,15 +413,16 @@ second test, a third value exists. ``prefixItems`` contrains only two
 items, and ``unevaluatedItems`` applies only to those two.
 
 .. note::
-   For a tall list of more examples, read our `unevaluatedItems Test Suite <https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/unevaluatedItems.json>`_ on GitHub.
-   We test a lot of use cases there, including uncommon ones. Do any
-   of these apply to your schema?
-   - ``unevaluatedItems`` nested inside another ``unevaluatedItems``
-   - ``if/then/else`` statements interacting with ``unevaluatedItems``
-   -  nested ``if/then/else`` statements interacting with ``unevaluatedItems``
-   - ``unevaluatedItems`` ignoring non-arrays
-   - ``unevaluatedItems`` interacting with the ``not`` keyword
-   - and more
+   For a tall list of more examples, read our `unevaluatedItems Test Suite <https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/unevaluatedItems.json>`_ on GitHub. We test a lot of use cases
+   there, including uncommon ones.
+
+Here are some of our examples in the suite:
+   * ``unevaluatedItems`` nested inside another ``unevaluatedItems``
+   * ``if/then/else`` statements interacting with ``unevaluatedItems``
+   * nested ``if/then/else`` statements interacting with ``unevaluatedItems``
+   * ``unevaluatedItems`` ignoring non-arrays
+   * ``unevaluatedItems`` interacting with the ``not`` keyword
+   * and more
 
 .. index::
    single: array; contains

--- a/source/reference/array.rst
+++ b/source/reference/array.rst
@@ -331,11 +331,11 @@ use ``$ref`` and add another item like this:
         { "type": "number" }
       ],
 
-        "$defs": {
-          "closed": {
-            "$anchor": "closed",
-            "$ref": "#",
-            "unevaluatedItems": false
+      "$defs": {
+        "closed": {
+          "$anchor": "closed",
+          "$ref": "#",
+          "unevaluatedItems": false
         }
       }
     }

--- a/source/reference/array.rst
+++ b/source/reference/array.rst
@@ -236,7 +236,200 @@ Unevaluated Items
 
 |draft2019-09|
 
-Documentation Coming Soon
+The ``unevaluatedItems`` keyword selects any data types not evaluated
+by an ``items``, ``prefixItems``, or `contains` keyword. Just as
+unevaluated"properties" affect only "properties" in an object, only
+"item"-related keywords affect unevaluated"items".
+
+It also applies inside valid subschemas with these keywords:
+- ``allOf``
+- ``anyOf``
+- ``oneOf``
+- ``not``
+- ``if``
+- ``then``
+- ``else``
+
+The main reason to use this keyword is to extend an array with extra
+arguments.
+
+For this first example, we'll use ``unevaluatedItems`` to select any
+unexpected strings.
+
+.. schema_example::
+
+    {
+        "items": {"type": "number"},
+        "unevaluatedItems": {"type": "string"}
+    }
+    --X
+    // If any strings appear, then the schema doesn't validate. There are no unevaluated items in that case.
+    { 99, "waffles" }
+    --
+    // But it passes so long as JSON finds all entries in an ``items``, ``prefixItems``, or ``contains``. There *are* unevaluated items in that case.
+    { 99, 0, 3.14159 }
+
+.. note::
+Watch out! The word "unevaluated" *does not* mean "not evaluated by
+``items``, ``prefixItems``, or ``contains``." "Unevaluated" means
+"not successfully evaluated", or "doesn't evaluate to true".
+
+You can also set ``unevaluatedItems`` as a boolean.
+
+.. schema_example::
+
+    {
+        "description": "unevaluatedItems with nested tuple",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                { "type": "string" }
+            ],
+            "allOf": [
+                {
+                    "prefixItems": [
+                      true,
+                      { "type": "number" }
+                    ]
+                }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": ["foo", 42],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", 42, null],
+                "valid": false
+            }
+        ]
+    }
+
+In the first test, all the "data" items are evaluated, but in the
+second test, the ``null`` value is a type not specified by
+``prefixItems``. It's therefore valid and ``true`` that
+``unevaluatedItems`` returns ``false`` in the first test, and invalid
+and ``false`` in the second test. In other words, it is valid that no
+unevaluated items exist until something not matching the string/number
+pattern shows up.
+
+You can also select ``unevaluatedItems`` when and only when an ``if``
+statement runs.
+
+.. schema_example::
+
+    {
+            "description": "unevaluatedItems can see annotations from if even without then and else",
+            "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "if": {
+                    "prefixItems": [{"const": "a"}]
+                },
+                "unevaluatedItems": false
+            },
+            "tests": [
+                {
+                    "description": "valid in case if is evaluated",
+                    "data": [ "a" ],
+                    "valid": true
+                },
+                {
+                    "description": "invalid in case if is evaluated",
+                    "data": [ "b" ],
+                    "valid": false
+                }
+            ]
+    }
+
+And an important note: ``unevaluatedItems`` can't see inside cousins
+(a vertically adjacent item inside a separate pair of {curly braces}
+with the same "parent"— ``anyOf``, ``if``, ``not``, or similar). Such
+an instance always fails evaluation.
+
+.. schema_example::
+
+    {
+        "description": "unevaluatedItems can't see inside cousins",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                  "prefixItems": [ true ]
+                },
+                { "unevaluatedItems": false }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": [ 1 ],
+                "valid": false
+            }
+        ]
+    }
+
+Finally, here's an example of ``unevaluatedItems`` if you're
+`structuring`. Let's make a "half-closed" schema: something useful
+when you want to keep the first two arguments, but also add more in
+certain situations. ("Closed" to two in some places, "open" to more
+in others.)
+
+.. schema_example::
+
+    {
+      "$id": "https://example.com/my-tuple",
+
+      "type": "array",
+      "prefixItems": [
+        true,
+        { "type": "boolean" }
+      ],
+
+      "$defs": {
+        "closed": {
+          "$anchor": "closed",
+          "$ref": "#",
+          "unevaluatedItems": false
+        }
+      }
+    }
+
+Then we can extend the tuple:
+
+.. schema_example::
+
+    {
+      "$id": "https://example.com/my-extended-tuple",
+
+      "$ref": "/my-tuple",
+      "prefixItems": [
+        true,
+        true,
+        { "type": "boolean" }
+      ],
+      "unevaluatedItems": false
+    }
+
+With this, you can use ``$ref`` to reference the first two
+``prefixItems`` and keep the schema "closed" to two when necessary,
+"open" to more when necessary. A reference to ``/my-tuple#closed``
+would disallow more than two items, when you need it to.
+
+.. note::
+   For a tower of more examples, read our `unevaluatedItems Test Suite <https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/unevaluatedItems.json>`_ on GitHub.
+   We test a lot of use cases there, including uncommon ones. Do any
+   of these apply to your schema?
+   - using ``unevaluatedItems`` as a schema
+   - ``unevaluatedItems`` nested inside another ``unevaluatedItems``
+   - ``if/then/else`` statements with ``unevaluatedItems``
+   - multiples nested ``if``/``then``s
+   - multiple nested instances of ``contains``
+   - ignoring non-array types
+   - ``not``
 
 .. index::
    single: array; contains

--- a/source/reference/array.rst
+++ b/source/reference/array.rst
@@ -236,19 +236,41 @@ Unevaluated Items
 
 |draft2019-09|
 
-The ``unevaluatedItems`` keyword applies to any values not evaluated
-by an ``items``, ``prefixItems``, or ``contains`` keyword. Just as
+The ``unevaluatedItems`` keyword is useful mainly when you want to add
+or disallow extra items to an array.
+
+``unevaluatedItems`` applies to any values not evaluated by an
+``items``, ``prefixItems``, or ``contains`` keyword. Just as
 ``unevaluatedProperties`` affects only **properties** in an object,
 ``unevaluatedItems`` affects only **items** in an array.
 
 .. note::
     Watch out! The word "unevaluated" *does not mean* "not evaluated by
     ``items``, ``prefixItems``, or ``contains``." "Unevaluated" means
-    "not successfully evaluated", or "doesn't evaluate to true".
+    "not successfully evaluated", or "does not evaluate to true".
 
-``items`` doesn't "see inside" any instances of ``allOf``, ``anyOf``,
-or ``oneOf`` in the same subschema. In this first example, ``items``
-ignores ``allOf`` and thus fails to validate.
+Like with ``items``, if you set ``unevaluatedItems`` to ``false``, you
+can disallow extra items in the array.
+
+.. schema_example::
+
+    {
+      "prefixItems": [
+        { "type": "string" }, { "type": "number" }
+      ],
+      "unevaluatedItems": false
+    }
+    --
+    ["foo", 42]
+    // All the values are evaluated. The schema passes validation.
+    --X
+    ["foo", 42, null]
+    // The schema fails validation because ``"unevaluatedItems": false"``
+    // specifies no extra values should exist.
+
+Note that ``items`` doesn't "see inside" any instances of ``allOf``,
+``anyOf``, or ``oneOf`` in the same subschema. So in this next example,
+``items`` ignores ``allOf`` and thus fails to validate.
 
 .. schema_example::
 
@@ -271,47 +293,26 @@ array validates.
     --
     [true, "a", 2]
 
-Like with ``items``, if you set ``unevaluatedItems`` to ``false``, you
-can disallow extra items in the array.
-
-.. schema_example::
-
-    {
-      "prefixItems": [
-        { "type": "string" }, { "type": "number" }
-      ],
-      "unevaluatedItems": false
-    }
-    --
-    ["foo", 42]
-    // All the values are evaluated. The schema passes validation.
-    --X
-    ["foo", 42, null]
-    // The schema fails validation because ``"unevaluatedItems": false"``
-    // specifies no extra values should exist.
-
-``unevaluatedItems`` is used mainly when extending a tuple. So with
-this in mind, you can make a "half-closed" schema: something useful
-when you want to keep the first two arguments, but also add more in
-certain situations. ("Closed" to two arguments in some places, "open"
-to more arguments when you need it to be.)
+You can also make a "half-closed" schema: something useful when you
+want to keep the first two arguments, but also add more in certain
+situations. ("Closed" to two arguments in some places, "open" to
+more arguments when you need it to be.)
 
 .. schema_example::
 
     {
       "$id": "https://example.com/my-tuple",
-
       "type": "array",
       "prefixItems": [
         { "type": "boolean" },
         { "type": "string" }
       ],
-      "unevaluatedItems": false,
 
       "$defs": {
         "closed": {
           "$anchor": "closed",
-          "$ref": "#"
+          "$ref": "#",
+          "unevaluatedItems": false
         }
       }
     }
@@ -323,26 +324,25 @@ use ``$ref`` and add another item like this:
 
     {
       "$id": "https://example.com/my-extended-tuple",
-
       "$ref": "https://example.com/my-tuple",
       "prefixItems": [
         { "type": "boolean" },
         { "type": "string" },
         { "type": "number" }
       ],
-      "unevaluatedItems": false,
 
         "$defs": {
-          "extended": {
-            "$anchor": "extended",
-            "$ref": "#"
+          "closed": {
+            "$anchor": "closed",
+            "$ref": "#",
+            "unevaluatedItems": false
         }
       }
     }
 
 Thus, you would reference ``my-tuple#closed`` when you need only
-two array items and reference ``my-tuple#extended`` when you need
-three items.
+two items and reference ``my-tuple#extended`` when you need three
+items.
 
 .. index::
    single: array; contains


### PR DESCRIPTION
One thing that guided me was my concurrence with @jdesrosiers on #198:

> I feel like UJS shouldn't be a cookbook of useful patterns and I feel like that's mostly what this is contributing. Since we don't have a cookbook, I'd be ok with merging this, but I do worry that it could be a slippery slope that results in ever increasing bloat

I included five examples: the ones I deemed to be the most common use cases. These were based on my conversations with others, a lot of Slack messages, and the [unevaluateditems.json in the test suite repo](https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/unevaluatedItems.json). I linked to that document at the bottom of the page in a note box and gave a short list of other cases readers might need. Five examples was already adding bloat to the page, and I don't think I can part with any of them. What do you think?

Feel free to remove, edit, or add things. I validated and checked multiple times, but I could have made some grievous factual error. This is just a rough draft, and I'm still lacking in "professional experience." I hope the links and other style bits turn out right.

Oh, and you don't mind if I add a link on my portfolio site to prove I wrote this, do you?