### PR TITLE
Don't let windows change line endings on scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+*.sh text eol=lf


### PR DESCRIPTION
The problem with running the docker build was that git was converting line endings from LF to CRLF. This broke the `entrypoint.sh` script.