### PR TITLE
Add deprecation notice in the UJS repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+---
+📌 **Deprecation Notice** 📌
+
+This repository is now deprecated. To contribute to the JSON Schema docs please use the new repository ➡️ [https://github.com/json-schema-org/website](https://github.com/json-schema-org/website).
+
+---
+
 understanding-json-schema
 =========================
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/json-schema-org/.github/blob/main/CODE_OF_CONDUCT.md) [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active) [![Financial Contributors on Open Collective](https://opencollective.com/json-schema/all/badge.svg?label=financial+contributors)](https://opencollective.com/json-schema)


### PR DESCRIPTION
With the release of the new JSON Schema website, the understanding JSON Schema documentation is now part of the website repository and as a consequence of it this repository is going to be deprecated. 

This PR os to add deprecation notice in the UJS repository. 

Huge thanks to everyone to contributed to this amazing documentation over the years!! Now the journey continues in https://github.com/json-schema-org/website

Thanks!!